### PR TITLE
Fix Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ dist: trusty
 install:
   - |
     curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash
-    sudo apt-get install -qy crystal build-essential llvm-3.6-dev libreadline-dev zlib1g-dev libedit-dev libssl-dev git
-    export LD_LIBRARY_PATH=/opt/crystal/embedded/lib/ LIBRARY_PATH=/opt/crystal/embedded/lib/
-    git clone https://github.com/manastech/crystal
-    (cd crystal && make)
-    export PATH="$(readlink -f crystal/bin):$PATH"
+    sudo apt-get install -qy crystal llvm-3.5-dev libreadline-dev build-essential zlib1g-dev libedit-dev libssl-dev
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
-language: crystal
-crystal:
-  - latest
+language: c
+sudo: required
+dist: trusty
+install:
+  - |
+    curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash
+    sudo apt-get install -qy crystal build-essential llvm-3.6-dev libreadline-dev zlib1g-dev libedit-dev libssl-dev git
+    export LD_LIBRARY_PATH=/opt/crystal/embedded/lib/ LIBRARY_PATH=/opt/crystal/embedded/lib/
+    git clone https://github.com/manastech/crystal
+    (cd crystal && make)
+    export PATH="$(readlink -f crystal/bin):$PATH"
 script:
   - make test
-before_install:
-  - sudo apt-get install llvm-dev


### PR DESCRIPTION
Well... this looks like a big problem. Seems like Crystal won't run on the ancient LLVM version anymore, and Ubuntu 12.04 on Travis doesn't provide any recent ones.

The Travis Crystal config for Ubuntu 14.04 [is broken](https://github.com/travis-ci/travis-ci/issues/5808)

Furthermore, even on Ubuntu 14.04 this whole setup did not work (same old linking errors) until I recompiled Crystal.

This is a complex file but I can't get it any smaller. Anyway, it [runs successfully](https://travis-ci.org/BlaXpirit/crystal-icr/builds/117702359)