### PR TITLE
Makefile: add install target with PREFIX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CRYSTAL_BIN ?= $(shell which crystal)
 ICR_BIN ?= $(shell which icr)
+PREFIX ?= /usr/local
 
 build:
 	$(CRYSTAL_BIN) build --release -o bin/icr src/icr/cli.cr $(CRFLAGS)
@@ -7,5 +8,8 @@ clean:
 	rm -f ./bin/icr
 test: build
 	$(CRYSTAL_BIN) spec
+install:
+	mkdir -p $(PREFIX)/bin
+	cp ./bin/icr $(PREFIX)/bin
 reinstall:
 	cp ./bin/icr $(ICR_BIN) -rf


### PR DESCRIPTION
This is useful for downstream packages like Homebrew to be able to have a consistent interface to install files. It means if you added e.g. a manpage or additional binaries in future we won't miss them.

CC @genki and https://github.com/Homebrew/homebrew-core/pull/1579