### PR TITLE
Makefile: install/reinstall depend on build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ clean:
 	rm -f ./bin/icr
 test: build
 	$(CRYSTAL_BIN) spec
-install:
+install: build
 	mkdir -p $(PREFIX)/bin
 	cp ./bin/icr $(PREFIX)/bin
-reinstall:
+reinstall: build
 	cp ./bin/icr $(ICR_BIN) -rf


### PR DESCRIPTION
Otherwise they'll try to copy something that doesn't exist.