### PR TITLE
Adding a "require" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ You can require local files by relative path (starts with `./`):
 require "./src/my_cool_lib"
 ```
 
+Libs can also be required from the cli
+
+```
+$ icr -r colorize -r ./src/my_cool_lib
+```
+
 ## Installation
 Prerequisites:
 * The latest version of crystal (0.18.0).

--- a/spec/icr_spec.cr
+++ b/spec/icr_spec.cr
@@ -1,4 +1,32 @@
 require "./spec_helper"
 
 describe Icr do
+
+  it "returns nothing for invalid option -c" do
+    icr("", "-c").should eq ""
+  end
+
+  it "returns the version for option -v" do
+    icr("", "-v").should contain(Icr::VERSION)
+  end
+
+  it "returns the help menu for option -h" do
+    icr("", "-h").should contain("Usage: icr [options]")
+  end
+
+  describe "using the -r option" do
+    it "requires the colorize lib" do
+      input = <<-CODE
+      "hello".responds_to?(:colorize)
+      CODE
+      icr(input, "-r colorize").should match /true/
+    end
+
+    it "fails when colorize is not required first" do
+      input = <<-CODE
+      "hello".responds_to?(:colorize)
+      CODE
+      icr(input).should match /false/
+    end
+  end
 end

--- a/spec/icr_spec.cr
+++ b/spec/icr_spec.cr
@@ -17,14 +17,14 @@ describe Icr do
   describe "using the -r option" do
     it "requires the colorize lib" do
       input = <<-CODE
-      "hello".responds_to?(:colorize)
+        "hello".responds_to?(:colorize)
       CODE
       icr(input, "-r colorize").should match /true/
     end
 
     it "fails when colorize is not required first" do
       input = <<-CODE
-      "hello".responds_to?(:colorize)
+        "hello".responds_to?(:colorize)
       CODE
       icr(input).should match /false/
     end

--- a/spec/icr_spec.cr
+++ b/spec/icr_spec.cr
@@ -1,32 +1,5 @@
 require "./spec_helper"
 
 describe Icr do
-
-  it "returns nothing for invalid option -c" do
-    icr("", "-c").should eq ""
-  end
-
-  it "returns the version for option -v" do
-    icr("", "-v").should contain(Icr::VERSION)
-  end
-
-  it "returns the help menu for option -h" do
-    icr("", "-h").should contain("Usage: icr [options]")
-  end
-
-  describe "using the -r option" do
-    it "requires the colorize lib" do
-      input = <<-CODE
-        "hello".responds_to?(:colorize)
-      CODE
-      icr(input, "-r colorize").should match /true/
-    end
-
-    it "fails when colorize is not required first" do
-      input = <<-CODE
-        "hello".responds_to?(:colorize)
-      CODE
-      icr(input).should match /false/
-    end
-  end
+  # specs defined in integration/icr_spec.cr
 end

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -22,13 +22,12 @@ describe "icr command" do
         icr(input, "-r colorize").should match /true/
       end
 
-      # This spec fails even though the code still works. Still investigating the cause
-      #it "requires multiple libs colorize and http" do
-      #  input = <<-CODE
-      #    "typeof(HTTP).name.responds_to?(:colorize)"
-      #  CODE
-      #  icr(input, "-r http", "-r colorize").should match /true/
-      #end
+      it "requires multiple libs colorize and http" do
+        input = <<-CODE
+          typeof(HTTP).name.responds_to?(:colorize)
+        CODE
+        icr(input, "-r http", "-r colorize").should match /true/
+      end
 
       it "fails when colorize is not required first" do
         input = <<-CODE

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -1,6 +1,36 @@
 require "../spec_helper"
 
 describe "icr command" do
+  context "passing flag arguments" do
+    it "returns nothing for invalid option -c" do
+      icr("", "-c").should eq ""
+    end
+
+    it "returns the version for option -v" do
+      icr("", "-v").should contain(Icr::VERSION)
+    end
+
+    it "returns the help menu for option -h" do
+      icr("", "-h").should contain("Usage: icr [options]")
+    end
+
+    describe "using the -r option" do
+      it "requires the colorize lib" do
+        input = <<-CODE
+          "hello".responds_to?(:colorize)
+        CODE
+        icr(input, "-r colorize").should match /true/
+      end
+
+      it "fails when colorize is not required first" do
+        input = <<-CODE
+          "hello".responds_to?(:colorize)
+        CODE
+        icr(input).should match /false/
+      end
+    end
+  end
+
   it "returns the passed value" do
     icr("13").should match /\=> 13/
     icr("\"Saluton\"").should match /\=> "Saluton"/

--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -22,6 +22,14 @@ describe "icr command" do
         icr(input, "-r colorize").should match /true/
       end
 
+      # This spec fails even though the code still works. Still investigating the cause
+      #it "requires multiple libs colorize and http" do
+      #  input = <<-CODE
+      #    "typeof(HTTP).name.responds_to?(:colorize)"
+      #  CODE
+      #  icr(input, "-r http", "-r colorize").should match /true/
+      #end
+
       it "fails when colorize is not required first" do
         input = <<-CODE
           "hello".responds_to?(:colorize)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,10 +2,14 @@ require "spec"
 require "../src/icr"
 
 # Execute icr command with the giving input and return stripped output.
+def icr(input : String)
+  icr(input, "")
+end
+
 # Optionally, you can pass flags to the icr command 
-def icr(input : String, arg : String? = nil)
+def icr(input : String, arg : String)
   cmd = ["#{Icr::ROOT_PATH}/bin/icr"]
-  cmd.push(arg) unless arg.nil?
+  cmd.push(arg) unless arg.empty?
 
   io_in = MemoryIO.new(input)
   io_out = MemoryIO.new

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,9 +7,9 @@ def icr(input : String)
 end
 
 # Optionally, you can pass flags to the icr command 
-def icr(input : String, arg : String)
+def icr(input : String, *args)
   cmd = ["#{Icr::ROOT_PATH}/bin/icr"]
-  cmd.push(arg) unless arg.empty?
+  cmd.push(*args) unless args.empty?
 
   io_in = MemoryIO.new(input)
   io_out = MemoryIO.new

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,13 +2,15 @@ require "spec"
 require "../src/icr"
 
 # Execute icr command with the giving input and return stripped output.
-def icr(input : String)
-  cmd = "#{Icr::ROOT_PATH}/bin/icr"
+# Optionally, you can pass flags to the icr command 
+def icr(input : String, arg : String? = nil)
+  cmd = ["#{Icr::ROOT_PATH}/bin/icr"]
+  cmd.push(arg) unless arg.nil?
 
   io_in = MemoryIO.new(input)
   io_out = MemoryIO.new
   io_error = MemoryIO.new
 
-  Process.run(cmd, nil, nil, false, true, io_in, io_out, io_error)
+  Process.run(cmd.join(" "), nil, nil, false, true, io_in, io_out, io_error)
   io_out.to_s.strip
 end

--- a/src/icr.cr
+++ b/src/icr.cr
@@ -13,7 +13,7 @@ require "./icr/syntax_check_result"
 require "./icr/console"
 
 module Icr
-  VERSION = "0.2.8"
+  VERSION = "0.2.9"
   AUTHOR = "Potapov Sergey"
   HOMEPAGE = "https://github.com/greyblake/crystal-icr"
 

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -2,7 +2,7 @@ require "option_parser"
 require "../icr"
 
 is_debug = false
-code = ""
+libs = [] of String
 
 def print_stamp
   puts "Author: #{Icr::AUTHOR}"
@@ -30,8 +30,9 @@ OptionParser.parse! do |parser|
   end
 
   parser.on("-r FILE", "--require=FILE", "auto require FILE") do |filename|
-    code = "require \"#{filename}\""
+    libs.push(%{require "#{filename}"})
   end
 end
 
+code = libs.join(";")
 Icr::Console.new(is_debug).start(code)

--- a/src/icr/cli.cr
+++ b/src/icr/cli.cr
@@ -2,6 +2,7 @@ require "option_parser"
 require "../icr"
 
 is_debug = false
+code = ""
 
 def print_stamp
   puts "Author: #{Icr::AUTHOR}"
@@ -27,6 +28,10 @@ OptionParser.parse! do |parser|
   parser.on("-d", "--debug", "Run icr in debug mode") do
     is_debug = true
   end
+
+  parser.on("-r FILE", "--require=FILE", "auto require FILE") do |filename|
+    code = "require \"#{filename}\""
+  end
 end
 
-Icr::Console.new(is_debug).start
+Icr::Console.new(is_debug).start(code)

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -9,7 +9,8 @@ module Icr
       @crystal_version = get_crystal_version!
     end
 
-    def start
+    def start(code : String)
+      process_input(code) unless code.empty?
       loop do
         input = ask_for_input
         process_input(input)

--- a/src/icr/console.cr
+++ b/src/icr/console.cr
@@ -9,6 +9,10 @@ module Icr
       @crystal_version = get_crystal_version!
     end
 
+    def start
+      start("")
+    end
+
     def start(code : String)
       process_input(code) unless code.empty?
       loop do


### PR DESCRIPTION
These commits add in an optional `-r` or `--require` flag which allows you to load icr with a particular package required. As well as some additional specs 😄 

```text
$ icr -r colorize
icr(0.18.7) > "hello".colorize(:blue)
 => "hello"
```

Without using the `-r` flag, the `colorize` method would not exist

```text
$ icr
icr(0.18.7) > "hello".colorize(:blue)
undefined method 'colorize' for String

  "hello".colorize(:blue)
          ^~~~~~~~
```