### PR TITLE
Added support for records and added unit test

### DIFF
--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -69,6 +69,18 @@ describe "icr command" do
     icr(input).should match /\=> 169/
   end
 
+  it "allows to define records" do
+    input = <<-CRYSTAL
+      record Person, first_name : String, last_name : String do
+        def full_name
+          first_name + " " + last_name
+        end
+      end
+      Person.new("Mike", "Nog").full_name
+    CRYSTAL
+    icr(input).should match /Mike Nog/
+  end
+
   describe "errors" do
     it "prints syntax error without crashing" do
       input = <<-CRYSTAL

--- a/src/icr/command_stack.cr
+++ b/src/icr/command_stack.cr
@@ -18,7 +18,9 @@ module Icr
       elsif command.strip =~ /^class\s/
         type = :class
       elsif command.strip =~ /^module\s/
-        type = :module
+	type = :module
+      elsif command.strip =~ /^record\s/
+        type = :record
       else
         type = :regular
       end
@@ -38,6 +40,7 @@ module Icr
         #{code(:module)}
         #{code(:class)}
         #{code(:method)}
+        #{code(:record)}
 
         def __icr_exec__
         #{code(:regular, 1)}


### PR DESCRIPTION
You can now define records in ICR i thought i would have a go at adding it i've also included a  unit test which passes also.

Example:

[brian@orville crystal-icr]$ bin/icr 
icr(0.18.6) > record Person, first_name : String, last_name : String do
icr(0.18.6) >     
icr(0.18.6) >     def full_name
icr(0.18.6) >       "#{first_name} #{last_name}"
icr(0.18.6) >     end
icr(0.18.6) >     
icr(0.18.6) >   end
 => ok
icr(0.18.6) > 
icr(0.18.6) > a = Person.new("Mike", "Nog").full_name
 => "Mike Nog"
icr(0.18.6) > quit

[brian@orville crystal-icr]$ make test
/data2/crystal/bin/crystal build --release -o bin/icr src/icr/cli.cr 
Deprecation: The build command was renamed to compile and will be removed in a future version.
/data2/crystal/bin/crystal spec
................

Finished in 55.39 seconds
16 examples, 0 failures, 0 errors, 0 pending
