### PR TITLE
Feature/shard postinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.shards/
 
 /bin/icr
+src/bin

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,10 @@
 name: icr
-version: 0.1.0
+version: 0.2.10
 
 authors:
   - Potapov Sergey <blake131313@gmail.com>
 
 license: MIT
+
+scripts:
+  postinstall: make install

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,15 @@
+CRYSTAL_BIN ?= $(shell which crystal)
+ICR_BIN ?= $(shell which icr)
+PREFIX ?= /usr/local
+
+build:
+	$(CRYSTAL_BIN) build --release -o bin/icr src/icr/cli.cr $(CRFLAGS)
+clean:
+	rm -f ./bin/icr
+test: build
+	$(CRYSTAL_BIN) spec
+install: build
+	mkdir -p $(PREFIX)/bin
+	cp ./bin/icr $(PREFIX)/bin
+reinstall: build
+	cp ./bin/icr $(ICR_BIN) -rf

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,8 @@
+# This Makefile is only used for compiling icr 
+# when added as a dependency to another project.
+# This may go away in a future version if the shards postinstall command changes.
+#
+
 CRYSTAL_BIN ?= $(shell which crystal)
 PREFIX ?= /usr/local
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,15 +1,7 @@
 CRYSTAL_BIN ?= $(shell which crystal)
-ICR_BIN ?= $(shell which icr)
 PREFIX ?= /usr/local
 
-build:
+install:
 	$(CRYSTAL_BIN) build --release -o bin/icr icr/cli.cr $(CRFLAGS)
-clean:
-	rm -f ./bin/icr
-test: build
-	$(CRYSTAL_BIN) spec
-install: build
 	mkdir -p $(PREFIX)/bin
 	cp ./bin/icr $(PREFIX)/bin
-reinstall: build
-	cp ./bin/icr $(ICR_BIN) -rf


### PR DESCRIPTION
This PR would allow icr to be included in a project as a shard dependency. Currently, when you install a dependency shard, only the contents of the `src` folder is copied over. By adding in an additional Makefile to the src folder, we can do a postinstall `make install`. I ran this locally, and it works great; however, testing it is sort of confusing. 

To test:
* make sure no `/usr/local/bin/icr` exists.
* Create a new project with a `shard.yml` and icr as a dependency
* run `shards install`. 

You should see out put that looks like

```text
updating https://github.com/greyblake/crystal-icr.git
Installing icr (0.2.10)
Postinstall make install
```

That last Postinall bit being the key. Once that runs, you'll have a `icr` command available.