### PR TITLE
updating for Crystal 0.20 compatibility

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,9 +11,9 @@ def icr(input : String, *args)
   cmd = ["#{Icr::ROOT_PATH}/bin/icr"]
   cmd.push(*args) unless args.empty?
 
-  io_in = MemoryIO.new(input)
-  io_out = MemoryIO.new
-  io_error = MemoryIO.new
+  io_in = IO::Memory.new(input)
+  io_out = IO::Memory.new
+  io_error = IO::Memory.new
 
   Process.run(cmd.join(" "), nil, nil, false, true, io_in, io_out, io_error)
   io_out.to_s.strip

--- a/src/icr.cr
+++ b/src/icr.cr
@@ -1,6 +1,6 @@
 require "readline"
 require "tempfile"
-require "io/memory_io"
+require "io/memory"
 require "secure_random"
 
 require "compiler/crystal/syntax"

--- a/src/icr/executer.cr
+++ b/src/icr/executer.cr
@@ -16,8 +16,8 @@ module Icr
 
     def execute
       File.write(@tmp_file_path, @command_stack.to_code)
-      io_out = MemoryIO.new
-      io_error = MemoryIO.new
+      io_out = IO::Memory.new
+      io_error = IO::Memory.new
       command = "#{CRYSTAL_COMMAND} #{@tmp_file_path}"
       status = Process.run(command, nil, nil, false, true, nil, io_out, io_error)
       print_source_file if @debug


### PR DESCRIPTION
With the latest Crystal release of 0.20.0, there's a few breaking changes causing this error:

```
Failed make install:
/usr/local/bin/crystal build --release -o bin/icr src/icr/cli.cr 
Error in src/icr/cli.cr:2: while requiring "../icr"

require "../icr"
^

in src/icr.cr:3: while requiring "io/memory_io": can't find file 'io/memory_io' relative to '/Users/jeremywoertink/Sites/bar.cr/lib/icr/src'

require "io/memory_io"
^

make: *** [build] Error 1
```

This PR fixes the compatibility error.