### PR TITLE
Fix: Cannot install aur package in Archlinux

### DIFF
--- a/spec/integration/icr_spec.cr
+++ b/spec/integration/icr_spec.cr
@@ -171,7 +171,7 @@ describe "icr command" do
     it "prints runtime error without crashing" do
       input = "\"5a\".to_i"
       output = icr(input)
-      output.should match /invalid Int32: 5a \(ArgumentError\)/
+      output.should match /Invalid Int32: 5a \(ArgumentError\)/
     end
   end
 


### PR DESCRIPTION
Once of the specs is failing when installing on Archlinux, this is because the error message was changed in a newer crystal version.

This PR should correct the spec to expect the correct error message now.

<details>
Failures:                                                                                                         
                                                                                                     
  1) icr command errors prints runtime error without crashing               
     Failure/Error: output.should match /invalid Int32: 5a \(ArgumentError\)/
                                       
       Expected: "icr(0.22.0) > \"5a\".to_i\nInvalid Int32: 5a (ArgumentError)\n0x443f7b: *CallStack::unwind:Array(Pointer(Void)) at ??\n0x457875: to_i32 at /$sr/lib/crystal/string.cr 418:5\n0x45776c: to_i at /usr/lib/crystal/string.cr 319:5\n0x442350: __icr_exec__ at /home/marcos/.cache/pacaur/crystal-icr/src/cryst$l-icr-0.2.14/.icr_e27SIkubbKEdtGYOdnzmHA.cr 3:3\n0x43305d: __crystal_main at /home/marcos/.cache/pacaur/crystal-icr/src/crystal-icr-0.2.14/.icr_e27SIkubbKEdtG$OdnzmHA.cr 5:26\n0x442229: main at /usr/lib/crystal/main.cr 12:15\n0x7f5709ad0511: __libc_start_main at ??\n0x43296a: _start at ??\n0x0: ??? at ??\nicr(0.22.0$ >"                                                                                                                
       to match: /invalid Int32: 5a \(ArgumentError\)/               
                                            
spec/integration/icr_spec.cr:174  
                                                                                                  
Finished in 21.05 seconds
26 examples, 1 failures, 0 errors, 0 pending

Failed examples:

crystal spec spec/integration/icr_spec.cr:171 # icr command errors prints runtime error without crashing


</details>