### PR TITLE
Remove latest version number as Crystal moves very fast.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ icr -r colorize -r ./src/my_cool_lib
 
 ## Installation
 Prerequisites:
-* The latest version of crystal (0.20.0).
+* The latest version of crystal.
 * Readline (for Debian/Ubuntu install `libreadline6-dev` package).
 * LLVM development files.
 


### PR DESCRIPTION
Crystal's latest version is `0.22.0` as of today.